### PR TITLE
chore: configure `changesets` to use this package as custom formatter and automate versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "../dist",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changesetformatterrc.json
+++ b/.changesetformatterrc.json
@@ -1,0 +1,6 @@
+{
+  "showCommitHash": true,
+  "categorize": true,
+  "capitalizeMessage": true,
+  "useEmojis": true
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "check": "biome check .",
-    "check:fix": "biome check --write ."
+    "check:fix": "biome check --write .",
+    "preversion": "npm run build",
+    "version": "changeset version",
+    "postversion": "node dist/cli/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This PR configures the project to use its own changeset-formatter for changelog formatting.